### PR TITLE
🎨 Improve artifact icons for better visual consistency

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1228,6 +1228,11 @@ body[data-theme="dark"] .skills .skillset .level-bar {
     color: white;
 }
 
+/* Make Android icon slightly bigger to fill the space better */
+.artifact-thumbnail .fa-android {
+    font-size: 30px;
+}
+
 .artifact-card.placeholder .artifact-thumbnail {
     background: linear-gradient(135deg, #6c757d 0%, #495057 100%);
     margin: 0 auto 1rem auto;

--- a/index.html
+++ b/index.html
@@ -514,7 +514,7 @@
                                     <!-- Project Card 2: JSON5-Kotlin -->
                                     <div class="artifact-card">
                                         <div class="artifact-thumbnail">
-                                            <i class="fab fa-kotlin"></i>
+                                            <i class="fas fa-code"></i>
                                         </div>
                                         <div class="artifact-info">
                                             <h4 class="artifact-title">JSON5-Kotlin</h4>


### PR DESCRIPTION
- Replace JSON5-Kotlin Kotlin logo with code block icon (fas fa-code) for better representation
- Adjust Android Device Catalog icon size to 30px for better space utilization
- Maintain consistent visual hierarchy between artifact thumbnails
- Balance icon sizes for harmonious appearance in green circular backgrounds

Icons now better represent their respective project types while maintaining visual consistency.