### PR TITLE
Fix/artifact icon sizing

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1254,8 +1254,10 @@ body[data-theme="dark"] .skills .skillset .level-bar {
     flex-shrink: 0;
 }
 
-.artifact-thumbnail i {
+.artifact-thumbnail svg.svg-inline--fa {
     font-size: 36px;
+    width: 36px;
+    height: 36px;
     color: white;
 }
 
@@ -1434,8 +1436,10 @@ body[data-theme="dark"] #toggleMoreProjects.btn-outline-primary:active {
         height: 50px;
     }
     
-    .artifact-thumbnail i {
+    .artifact-thumbnail svg.svg-inline--fa {
         font-size: 32px;
+        width: 32px;
+        height: 32px;
     }
     
     #toggleMoreProjects.btn-outline-primary {

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1255,13 +1255,8 @@ body[data-theme="dark"] .skills .skillset .level-bar {
 }
 
 .artifact-thumbnail i {
-    font-size: 28px;
-    color: white;
-}
-
-/* Make Android icon slightly bigger to fill the space better */
-.artifact-thumbnail .fa-android {
     font-size: 30px;
+    color: white;
 }
 
 .artifact-card.placeholder .artifact-thumbnail {
@@ -1440,7 +1435,7 @@ body[data-theme="dark"] #toggleMoreProjects.btn-outline-primary:active {
     }
     
     .artifact-thumbnail i {
-        font-size: 24px;
+        font-size: 26px;
     }
     
     #toggleMoreProjects.btn-outline-primary {

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1254,10 +1254,10 @@ body[data-theme="dark"] .skills .skillset .level-bar {
     flex-shrink: 0;
 }
 
-.artifact-thumbnail svg.svg-inline--fa {
-    font-size: 36px;
-    width: 36px;
-    height: 36px;
+.artifact-thumbnail svg.svg-inline--fa, .artifact-thumbnail i {
+    font-size: 30px;
+    width: 30px;
+    height: 30px;
     color: white;
 }
 
@@ -1435,11 +1435,11 @@ body[data-theme="dark"] #toggleMoreProjects.btn-outline-primary:active {
         width: 50px;
         height: 50px;
     }
-    
-    .artifact-thumbnail svg.svg-inline--fa {
-        font-size: 32px;
-        width: 32px;
-        height: 32px;
+
+    .artifact-thumbnail svg.svg-inline--fa, .artifact-thumbnail i {
+        font-size: 26px;
+        width: 26px;
+        height: 26px;
     }
     
     #toggleMoreProjects.btn-outline-primary {

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1255,7 +1255,7 @@ body[data-theme="dark"] .skills .skillset .level-bar {
 }
 
 .artifact-thumbnail i {
-    font-size: 30px;
+    font-size: 36px;
     color: white;
 }
 
@@ -1435,7 +1435,7 @@ body[data-theme="dark"] #toggleMoreProjects.btn-outline-primary:active {
     }
     
     .artifact-thumbnail i {
-        font-size: 26px;
+        font-size: 32px;
     }
     
     #toggleMoreProjects.btn-outline-primary {


### PR DESCRIPTION
This pull request updates the styling for artifact thumbnails in the dark theme to improve icon consistency and sizing for both SVG and font icons. The changes ensure that both SVG-based and font-based icons are styled uniformly across different screen sizes.

Icon styling improvements:

* Updated `.artifact-thumbnail` selectors to apply consistent `font-size`, `width`, `height`, and `color` properties to both SVG and font icons, replacing the previous approach that only targeted font icons and specific classes.
* Adjusted responsive styles for `.artifact-thumbnail` icons to ensure consistent sizing for SVG and font icons on smaller screens.