### PR TITLE
Refactor: Move H.K. Vision and Keep Alive to 'Show More Projects' section

### DIFF
--- a/index.html
+++ b/index.html
@@ -313,81 +313,6 @@
                                 <a class="btn btn-cta-secondary" href="https://github.com/hossain-khan/android-remote-notify" target="_blank"><i class="fab fa-github"></i> Learn More</a>
                             </div><!--//item-->
 
-
-                            <div class="item featured text-center"><!-- featured item-->
-                                <h3 class="title mb-3"><a href="https://github.com/hossain-khan/android-keep-alive" target="_blank"><i class="fab fa-android"></i> Android Keep Alive <em>(Experimental)</em></a></h3>
-                                <p class="summary">A simple app to keep specific apps alive by checking if they are running. If not, they will be started for you.</p>
-                                <div class="featured-image has-ribbon">
-                                    <a href="https://github.com/hossain-khan/android-keep-alive" target="_blank">
-                                        <img class="img-fluid project-image rounded shadow-sm" src="assets/images/projects/keep-alive-banner-art.png" alt="Android Keep Alive Project Banner Image">
-                                    </a>
-                                    <div class="ribbon">
-                                        <div class="text">Alpha</div>
-                                    </div>
-                                </div>
-
-                                <div class="desc text-start">
-                                    <p>
-                                        This app is designed with a very specific use case in mind. It is important to understand what this app does and how.
-                                    </p>
-                                    <ul>
-                                        <li>App is designed to be always running in the foreground to watch and restart other applications.</li>
-                                        <li>App is NOT optimized for battery and will cause high battery 🪫 drain. Ideally, this should not be used on your primary phone that you use daily.</li>
-                                        <li>ℹ️ I use this on a secondary phone plugged into a power cable 24/7.</li>
-                                        <li>App contains some additional features like Remote Logging and Heartbeat due to my personal needs. However, the app can be used without using those features.</li>
-                                    </ul>
-                                    <p>See the permission section in the README to better understand the app and it's functionalities.</p>
-                                </div><!--//desc-->
-                                <a class="btn btn-cta-secondary" href="https://github.com/hossain-khan/android-keep-alive/releases" target="_blank"><i class="fas fa-pie-chart"></i> Test drive</a>
-                                <a class="btn btn-cta-secondary" href="https://github.com/hossain-khan/android-keep-alive" target="_blank"><i class="fab fa-github"></i> Learn More</a>
-                            </div><!--//item-->
-
-                            <div class="item featured text-center"><!-- featured item-->
-                                <h3 class="title mb-3"><a href="https://play.google.com/store/apps/details?id=com.hossainkhan.vision" target="_blank"><i class="fas fa-tv"></i> H.K. Vision Plugin for Muzei</a></h3>
-                                <p class="summary">A simple Muzei Live Wallpaper plugin for my H.K. Vision photography site.</p>
-
-                                <div class="featured-image has-ribbon">
-                                    <a href="https://play.google.com/store/apps/details?id=com.hossainkhan.vision"
-                                       target="_blank">
-                                        <img class="img-fluid project-image rounded shadow-sm"
-                                             src="assets/images/projects/android-muzei-plugin-feature-graphic-v3.png"
-                                             alt="H.K. Vision Muzei Plugin for Android">
-                                    </a>
-                                    <div class="ribbon">
-                                        <div class="text">Beta</div>
-                                    </div>
-                                </div>
-
-                                <div class="desc text-start">
-                                    <p>&quot;Vision Muzei Plugin&quot; is an Android plugin for my <b>H.K. Vision</b> <i class="fas fa-camera-retro" aria-hidden="true"></i> <a href="https://vision.hossainkhan.com/" class="dimmed-link">photography site</a>.
-                                        The plugin app allows users to use the featured photos as background wallpaper on their Android phone that automatically changes over time.</p>
-                                    <p>To get advantage of this plugin, you <b>must</b> install the <a href="https://play.google.com/store/apps/details?id=net.nurik.roman.muzei">Muzei Live Wallpaper</a> app on your phone.
-                                        Once installed, you can then install this plugin and the H.K. Vision featured photos will show as a "source" inside the Muzei app.
-                                    </p>
-                                    <p>Here is an example, where it shows how the H.K. Vision image source shows inside the <a href="https://play.google.com/store/apps/details?id=net.nurik.roman.muzei">Muzei app</a>
-                                        &amp; how you can select photo and customize it:</p>
-                                    <div class="featured-image has-ribbon">
-                                        <a href="assets/images/projects/android-muzei-plugin-demo-large.png"
-                                           target="_blank">
-                                            <img class="img-fluid project-image"
-                                                 src="assets/images/projects/android-muzei-plugin-demo-large-small.png"
-                                                 alt="H.K. Vision Muzei Plugin for Android Demo Screenshots">
-                                        </a>
-                                        <div class="ribbon">
-                                            <div class="text">Demo</div>
-                                        </div>
-                                    </div><!--//featured-image-->
-                                    <p>The application is Open Source and available in <i class="fab fa-github-alt"></i><a href="https://github.com/hossain-khan/android-hk-vision-muzei-plugin" target="_blank">Github</a>. If you have a similar source, you may also be interested in creating a plugin for it <i class="far fa-thumbs-up" aria-hidden="true"></i></p>
-                                </div><!--//desc-->
-                                <a class="btn btn-cta-secondary"
-                                   href="https://play.google.com/store/apps/details?id=com.hossainkhan.vision"
-                                   target="_blank"><i class="fa-brands fa-google-play"></i> Get it on Google Play&trade;</a>
-                                <a class="btn btn-cta-secondary"
-                                   href="https://medium.com/@hossainkhan/hackathon-creating-the-simplest-muzei-wallpaper-plugin-for-android-9d080dbb4bf" target="_blank"><i
-                                        class="fa fa-book"></i> Read more on Medium</a>
-                            </div><!--//item-->
-
-
                             <!-- ========================================================================= -->
                             <hr class="divider"><!-- divider between featured and non-featured items -->
                             <!-- ========================================================================= -->
@@ -410,6 +335,48 @@
                             <!--        <p><a class="more-link" href="https://themes.3rdwavemedia.com/bootstrap-templates/startup/coderpro-bootstrap-4-startup-template-for-software-projects/" target="_blank"><i class="fas fa-external-link-alt"></i>Find out more</a></p>-->
                             <!--    </div>&lt;!&ndash;//desc&ndash;&gt;                          -->
                             <!--</div>&lt;!&ndash;//item&ndash;&gt;-->
+
+                            <div class="item row">
+                                <a class="col-md-4 col-12" href="https://github.com/hossain-khan/android-keep-alive" target="_blank">
+                                    <img class="img-fluid project-image rounded shadow-sm" src="assets/images/projects/keep-alive-banner-art.png" alt="Android Keep Alive Project Banner Image">
+                                </a>
+                                <div class="desc col-md-8 col-12">
+                                    <h3 class="title"><a href="https://github.com/hossain-khan/android-keep-alive" target="_blank"><i class="fab fa-android"></i> Android Keep Alive <em>(Experimental)</em></a></h3>
+                                    <p class="summary">A simple app to keep specific apps alive by checking if they are running. If not, they will be started for you.</p>
+                                    <p>This app is designed with a very specific use case in mind. It is important to understand what this app does and how.</p>
+                                    <ul>
+                                        <li>App is designed to be always running in the foreground to watch and restart other applications.</li>
+                                        <li>App is NOT optimized for battery and will cause high battery 🪫 drain. Ideally, this should not be used on your primary phone that you use daily.</li>
+                                        <li>ℹ️ I use this on a secondary phone plugged into a power cable 24/7.</li>
+                                        <li>App contains some additional features like Remote Logging and Heartbeat due to my personal needs. However, the app can be used without using those features.</li>
+                                    </ul>
+                                    <p>See the permission section in the README to better understand the app and it's functionalities.</p>
+                                    <p>
+                                        <a class="more-link" href="https://github.com/hossain-khan/android-keep-alive/releases" target="_blank"><i class="fas fa-external-link-alt"></i> Test drive <i class="fas fa-pie-chart"></i></a> &nbsp;&nbsp;
+                                        <a class="more-link" href="https://github.com/hossain-khan/android-keep-alive" target="_blank"><i class="fas fa-external-link-alt"></i> Learn More <i class="fab fa-github"></i></a>
+                                    </p>
+                                </div><!--//desc-->
+                            </div><!--//item-->
+
+                            <div class="item row">
+                                <a class="col-md-4 col-12" href="https://play.google.com/store/apps/details?id=com.hossainkhan.vision" target="_blank">
+                                    <img class="img-fluid project-image rounded shadow-sm" src="assets/images/projects/android-muzei-plugin-feature-graphic-v3.png" alt="H.K. Vision Muzei Plugin for Android">
+                                </a>
+                                <div class="desc col-md-8 col-12">
+                                    <h3 class="title"><a href="https://play.google.com/store/apps/details?id=com.hossainkhan.vision" target="_blank"><i class="fas fa-tv"></i> H.K. Vision Plugin for Muzei</a></h3>
+                                    <p class="summary">A simple Muzei Live Wallpaper plugin for my H.K. Vision photography site.</p>
+                                    <p>&quot;Vision Muzei Plugin&quot; is an Android plugin for my <b>H.K. Vision</b> <i class="fas fa-camera-retro" aria-hidden="true"></i> <a href="https://vision.hossainkhan.com/" class="dimmed-link">photography site</a>.
+                                        The plugin app allows users to use the featured photos as background wallpaper on their Android phone that automatically changes over time.</p>
+                                    <p>To get advantage of this plugin, you <b>must</b> install the <a href="https://play.google.com/store/apps/details?id=net.nurik.roman.muzei">Muzei Live Wallpaper</a> app on your phone.
+                                        Once installed, you can then install this plugin and the H.K. Vision featured photos will show as a "source" inside the Muzei app.</p>
+                                    <p>The application is Open Source and available in <i class="fab fa-github-alt"></i> <a href="https://github.com/hossain-khan/android-hk-vision-muzei-plugin" target="_blank">Github</a>. If you have a similar source, you may also be interested in creating a plugin for it <i class="far fa-thumbs-up" aria-hidden="true"></i></p>
+                                    <p>
+                                        <a class="more-link" href="https://play.google.com/store/apps/details?id=com.hossainkhan.vision" target="_blank"><i class="fas fa-external-link-alt"></i> Get it on Google Play&trade;</a> &nbsp;&nbsp;
+                                        <a class="more-link" href="https://medium.com/@hossainkhan/hackathon-creating-the-simplest-muzei-wallpaper-plugin-for-android-9d080dbb4bf" target="_blank"><i class="fas fa-external-link-alt"></i> Read more on Medium</a>
+                                    </p>
+                                </div><!--//desc-->
+                            </div><!--//item-->
+
                             <div class="item row">
                                 <a class="col-md-4 col-12" href="https://github.com/hossain-khan/kgeo-timeline" target="_blank">
                                     <img class="img-fluid project-image rounded shadow-sm" src="assets/images/projects/kgeo-timeline.jpg" alt="KGeoTimeline Project Banner Image">


### PR DESCRIPTION
## Summary
This PR streamlines the main project showcase by moving two older projects to the "Show More Projects" section, converting them from the featured (large, centered) format to the compact non-featured (row-based) format.

## Changes
- ✅ Moved **H.K. Vision Plugin for Muzei** from featured section to "Show More Projects"
- ✅ Moved **Android Keep Alive (Experimental)** from featured section to "Show More Projects"
- ✅ Converted both projects to compact row-based layout following the existing pattern
- ✅ Maintains all key information while reducing visual prominence
- ✅ Streamlines main project showcase to focus on most recent work

## Impact
- **Net reduction**: 42 insertions(+), 75 deletions(-) - more concise page
- Improved focus on latest projects (TRMNL Buddy, Weather Alert, Remote Notify)
- Better organization with older projects hidden behind "Show More" toggle
- Consistent styling with other non-featured projects (KGeoTimeline, GitHub PR Stats, etc.)

## Testing
- [ ] Verify both projects appear correctly in "Show More Projects" section
- [ ] Confirm toggle button shows/hides the projects properly
- [ ] Check responsive layout on mobile and desktop
- [ ] Validate all links work correctly