### PR TITLE
Reorder vibe coded artifacts: move TRMNL Buddy and Camp Mate to top

### DIFF
--- a/index.html
+++ b/index.html
@@ -557,123 +557,26 @@
                             <!-- 16:9 Aspect Ratio Container -->
                             <div class="artifacts-viewport">
                                 <div class="artifacts-container">
-                                    <!-- Project Card 1: Android Keep Alive -->
+                                    <!-- Project Card 1: TRMNL Android Buddy -->
                                     <div class="artifact-card">
                                         <div class="artifact-thumbnail">
-                                            <i class="fas fa-heartbeat"></i>
+                                            <img src="assets/images/trmnl-buddy-trans-white.png" alt="TRMNL Buddy Icon" width="30" height="30">
                                         </div>
                                         <div class="artifact-info">
-                                            <h4 class="artifact-title">Android Keep Alive</h4>
-                                            <p class="artifact-description">A simple app to keep specific apps alive by checking if they are running and restarting them automatically</p>
+                                            <h4 class="artifact-title">TRMNL Buddy</h4>
+                                            <p class="artifact-description">Companion app to monitor and manage TRMNL e-ink displays with battery tracking, device health monitoring, and content feeds</p>
                                             <div class="artifact-tech">
                                                 <span class="tech-tag">Android</span>
                                                 <span class="tech-tag">Kotlin</span>
-                                                <span class="tech-tag">Services</span>
+                                                <span class="tech-tag">Jetpack Compose</span>
                                             </div>
-                                            <a href="https://github.com/hossain-khan/android-keep-alive" target="_blank" class="artifact-link">
+                                            <a href="https://github.com/hossain-khan/trmnl-android-buddy" target="_blank" class="artifact-link">
                                                 <i class="fas fa-external-link-alt"></i> View on GitHub
                                             </a>
                                         </div>
                                     </div>
 
-                                    <!-- Project Card 2: Android Device Catalog Browser -->
-                                    <div class="artifact-card">
-                                        <div class="artifact-thumbnail">
-                                            <i class="fab fa-android"></i>
-                                        </div>
-                                        <div class="artifact-info">
-                                            <h4 class="artifact-title">Android Device Catalog</h4>
-                                            <p class="artifact-description">Interactive browser for exploring and analyzing Android devices from the official Device Catalog</p>
-                                            <div class="artifact-tech">
-                                                <span class="tech-tag">React</span>
-                                                <span class="tech-tag">TypeScript</span>
-                                                <span class="tech-tag">Vite</span>
-                                            </div>
-                                            <a href="https://android-device.gohk.xyz/" target="_blank" class="artifact-link">
-                                                <i class="fas fa-external-link-alt"></i> See Android Catalog
-                                            </a>
-                                        </div>
-                                    </div>
-
-                                    <!-- Project Card 3: JSON5-Kotlin -->
-                                    <div class="artifact-card">
-                                        <div class="artifact-thumbnail">
-                                            <i class="fas fa-code"></i>
-                                        </div>
-                                        <div class="artifact-info">
-                                            <h4 class="artifact-title">JSON5-Kotlin</h4>
-                                            <p class="artifact-description">Robust JSON5 parser and serializer for Kotlin with modern architecture and type safety</p>
-                                            <div class="artifact-tech">
-                                                <span class="tech-tag">Kotlin</span>
-                                                <span class="tech-tag">JSON5</span>
-                                                <span class="tech-tag">Serialization</span>
-                                            </div>
-                                            <a href="https://hossain-khan.github.io/json5-kotlin/" target="_blank" class="artifact-link">
-                                                <i class="fas fa-external-link-alt"></i> View Library Docs
-                                            </a>
-                                        </div>
-                                    </div>
-
-                                    <!-- Project Card 4: Canadian Mortgage Accelerator Calculator -->
-                                    <div class="artifact-card">
-                                        <div class="artifact-thumbnail">
-                                            <i class="fas fa-calculator"></i>
-                                        </div>
-                                        <div class="artifact-info">
-                                            <h4 class="artifact-title">Canadian Mortgage Accelerator</h4>
-                                            <p class="artifact-description">Interactive mortgage calculator with acceleration strategies to help Canadian homeowners pay off mortgages faster</p>
-                                            <div class="artifact-tech">
-                                                <span class="tech-tag">React</span>
-                                                <span class="tech-tag">TypeScript</span>
-                                                <span class="tech-tag">Charts</span>
-                                            </div>
-                                            <a href="https://mortgage.gohk.xyz/" target="_blank" class="artifact-link">
-                                                <i class="fas fa-external-link-alt"></i> Calculate Mortgage
-                                            </a>
-                                        </div>
-                                    </div>
-
-                                    <!-- Project Card 5: Social Sync -->
-                                    <div class="artifact-card">
-                                        <div class="artifact-thumbnail">
-                                            <i class="fas fa-sync-alt"></i>
-                                        </div>
-                                        <div class="artifact-info">
-                                            <h4 class="artifact-title">Social Sync</h4>
-                                            <p class="artifact-description">Python-based tool to automatically sync posts from Bluesky to Mastodon with GitHub Actions automation</p>
-                                            <div class="artifact-tech">
-                                                <span class="tech-tag">Python</span>
-                                                <span class="tech-tag">API</span>
-                                                <span class="tech-tag">Automation</span>
-                                            </div>
-                                            <a href="https://github.com/hossain-khan/social-sync" target="_blank" class="artifact-link">
-                                                <i class="fas fa-external-link-alt"></i> View on GitHub
-                                            </a>
-                                        </div>
-                                    </div>
-
-                                    <!-- Project Card 6: Kids Math Adventure -->
-                                    <div class="artifact-card">
-                                        <div class="artifact-thumbnail">
-                                            <svg width="30" height="30" viewBox="0 0 256 256" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
-                                                <path d="M116,184a12,12,0,0,1-12,12H84v20a12,12,0,0,1-24,0V196H40a12,12,0,0,1,0-24H60V152a12,12,0,0,1,24,0v20h20A12,12,0,0,1,116,184ZM104,60H40a12,12,0,0,0,0,24h64a12,12,0,0,0,0-24Zm48,116.06641h64a12,12,0,0,0,0-24H152a12,12,0,0,0,0,24Zm64,15.86718H152a12,12,0,0,0,0,24h64a12,12,0,0,0,0-24Zm-64.48535-87.44824a12.00033,12.00033,0,0,0,16.9707,0L184,88.9707l15.51465,15.51465a12.0001,12.0001,0,0,0,16.9707-16.9707L200.9707,72l15.51465-15.51465a12.0001,12.0001,0,0,0-16.9707-16.9707L184,55.0293,168.48535,39.51465a12.0001,12.0001,0,0,0-16.9707,16.9707L167.0293,72,151.51465,87.51465A12.00062,12.00062,0,0,0,151.51465,104.48535Z"/>
-                                            </svg>
-                                        </div>
-                                        <div class="artifact-info">
-                                            <h4 class="artifact-title">Kids Math Adventure</h4>
-                                            <p class="artifact-description">Interactive educational game that makes learning math fun and engaging for children through adventure-based gameplay</p>
-                                            <div class="artifact-tech">
-                                                <span class="tech-tag">React</span>
-                                                <span class="tech-tag">JavaScript</span>
-                                                <span class="tech-tag">Education</span>
-                                            </div>
-                                            <a href="https://kids-math.gohk.xyz/" target="_blank" class="artifact-link">
-                                                <i class="fas fa-external-link-alt"></i> Play Math Adventure
-                                            </a>
-                                        </div>
-                                    </div>
-
-                                    <!-- Project Card 7: Camp Mate -->
+                                    <!-- Project Card 2: Camp Mate -->
                                     <div class="artifact-card">
                                         <div class="artifact-thumbnail">
                                             <i class="fas fa-campground"></i>
@@ -692,21 +595,118 @@
                                         </div>
                                     </div>
 
-                                    <!-- Project Card 8: TRMNL Android Buddy -->
+                                    <!-- Project Card 3: Android Keep Alive -->
                                     <div class="artifact-card">
                                         <div class="artifact-thumbnail">
-                                            <img src="assets/images/trmnl-buddy-trans-white.png" alt="TRMNL Buddy Icon" width="30" height="30">
+                                            <i class="fas fa-heartbeat"></i>
                                         </div>
                                         <div class="artifact-info">
-                                            <h4 class="artifact-title">TRMNL Buddy</h4>
-                                            <p class="artifact-description">Companion app to monitor and manage TRMNL e-ink displays with battery tracking, device health monitoring, and content feeds</p>
+                                            <h4 class="artifact-title">Android Keep Alive</h4>
+                                            <p class="artifact-description">A simple app to keep specific apps alive by checking if they are running and restarting them automatically</p>
                                             <div class="artifact-tech">
                                                 <span class="tech-tag">Android</span>
                                                 <span class="tech-tag">Kotlin</span>
-                                                <span class="tech-tag">Jetpack Compose</span>
+                                                <span class="tech-tag">Services</span>
                                             </div>
-                                            <a href="https://github.com/hossain-khan/trmnl-android-buddy" target="_blank" class="artifact-link">
+                                            <a href="https://github.com/hossain-khan/android-keep-alive" target="_blank" class="artifact-link">
                                                 <i class="fas fa-external-link-alt"></i> View on GitHub
+                                            </a>
+                                        </div>
+                                    </div>
+
+                                    <!-- Project Card 4: Android Device Catalog Browser -->
+                                    <div class="artifact-card">
+                                        <div class="artifact-thumbnail">
+                                            <i class="fab fa-android"></i>
+                                        </div>
+                                        <div class="artifact-info">
+                                            <h4 class="artifact-title">Android Device Catalog</h4>
+                                            <p class="artifact-description">Interactive browser for exploring and analyzing Android devices from the official Device Catalog</p>
+                                            <div class="artifact-tech">
+                                                <span class="tech-tag">React</span>
+                                                <span class="tech-tag">TypeScript</span>
+                                                <span class="tech-tag">Vite</span>
+                                            </div>
+                                            <a href="https://android-device.gohk.xyz/" target="_blank" class="artifact-link">
+                                                <i class="fas fa-external-link-alt"></i> See Android Catalog
+                                            </a>
+                                        </div>
+                                    </div>
+
+                                    <!-- Project Card 5: JSON5-Kotlin -->
+                                    <div class="artifact-card">
+                                        <div class="artifact-thumbnail">
+                                            <i class="fas fa-code"></i>
+                                        </div>
+                                        <div class="artifact-info">
+                                            <h4 class="artifact-title">JSON5-Kotlin</h4>
+                                            <p class="artifact-description">Robust JSON5 parser and serializer for Kotlin with modern architecture and type safety</p>
+                                            <div class="artifact-tech">
+                                                <span class="tech-tag">Kotlin</span>
+                                                <span class="tech-tag">JSON5</span>
+                                                <span class="tech-tag">Serialization</span>
+                                            </div>
+                                            <a href="https://hossain-khan.github.io/json5-kotlin/" target="_blank" class="artifact-link">
+                                                <i class="fas fa-external-link-alt"></i> View Library Docs
+                                            </a>
+                                        </div>
+                                    </div>
+
+                                    <!-- Project Card 6: Canadian Mortgage Accelerator Calculator -->
+                                    <div class="artifact-card">
+                                        <div class="artifact-thumbnail">
+                                            <i class="fas fa-calculator"></i>
+                                        </div>
+                                        <div class="artifact-info">
+                                            <h4 class="artifact-title">Canadian Mortgage Accelerator</h4>
+                                            <p class="artifact-description">Interactive mortgage calculator with acceleration strategies to help Canadian homeowners pay off mortgages faster</p>
+                                            <div class="artifact-tech">
+                                                <span class="tech-tag">React</span>
+                                                <span class="tech-tag">TypeScript</span>
+                                                <span class="tech-tag">Charts</span>
+                                            </div>
+                                            <a href="https://mortgage.gohk.xyz/" target="_blank" class="artifact-link">
+                                                <i class="fas fa-external-link-alt"></i> Calculate Mortgage
+                                            </a>
+                                        </div>
+                                    </div>
+
+                                    <!-- Project Card 7: Social Sync -->
+                                    <div class="artifact-card">
+                                        <div class="artifact-thumbnail">
+                                            <i class="fas fa-sync-alt"></i>
+                                        </div>
+                                        <div class="artifact-info">
+                                            <h4 class="artifact-title">Social Sync</h4>
+                                            <p class="artifact-description">Python-based tool to automatically sync posts from Bluesky to Mastodon with GitHub Actions automation</p>
+                                            <div class="artifact-tech">
+                                                <span class="tech-tag">Python</span>
+                                                <span class="tech-tag">API</span>
+                                                <span class="tech-tag">Automation</span>
+                                            </div>
+                                            <a href="https://github.com/hossain-khan/social-sync" target="_blank" class="artifact-link">
+                                                <i class="fas fa-external-link-alt"></i> View on GitHub
+                                            </a>
+                                        </div>
+                                    </div>
+
+                                    <!-- Project Card 8: Kids Math Adventure -->
+                                    <div class="artifact-card">
+                                        <div class="artifact-thumbnail">
+                                            <svg width="30" height="30" viewBox="0 0 256 256" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+                                                <path d="M116,184a12,12,0,0,1-12,12H84v20a12,12,0,0,1-24,0V196H40a12,12,0,0,1,0-24H60V152a12,12,0,0,1,24,0v20h20A12,12,0,0,1,116,184ZM104,60H40a12,12,0,0,0,0,24h64a12,12,0,0,0,0-24Zm48,116.06641h64a12,12,0,0,0,0-24H152a12,12,0,0,0,0,24Zm64,15.86718H152a12,12,0,0,0,0,24h64a12,12,0,0,0,0-24Zm-64.48535-87.44824a12.00033,12.00033,0,0,0,16.9707,0L184,88.9707l15.51465,15.51465a12.0001,12.0001,0,0,0,16.9707-16.9707L200.9707,72l15.51465-15.51465a12.0001,12.0001,0,0,0-16.9707-16.9707L184,55.0293,168.48535,39.51465a12.0001,12.0001,0,0,0-16.9707,16.9707L167.0293,72,151.51465,87.51465A12.00062,12.00062,0,0,0,151.51465,104.48535Z"/>
+                                            </svg>
+                                        </div>
+                                        <div class="artifact-info">
+                                            <h4 class="artifact-title">Kids Math Adventure</h4>
+                                            <p class="artifact-description">Interactive educational game that makes learning math fun and engaging for children through adventure-based gameplay</p>
+                                            <div class="artifact-tech">
+                                                <span class="tech-tag">React</span>
+                                                <span class="tech-tag">JavaScript</span>
+                                                <span class="tech-tag">Education</span>
+                                            </div>
+                                            <a href="https://kids-math.gohk.xyz/" target="_blank" class="artifact-link">
+                                                <i class="fas fa-external-link-alt"></i> Play Math Adventure
                                             </a>
                                         </div>
                                     </div>


### PR DESCRIPTION
## Changes

Reordered the "Vibe Coded Artifacts" section to highlight the most recent and actively developed projects:

### New Order:
1. **TRMNL Android Buddy** (moved from #8 → #1)
2. **Camp Mate** (moved from #7 → #2)
3. Android Keep Alive (was #1)
4. Android Device Catalog (was #2)
5. JSON5-Kotlin (was #3)
6. Canadian Mortgage Accelerator (was #4)
7. Social Sync (was #5)
8. Kids Math Adventure (was #6)
9. TRMNL Next Pickup Plugin (unchanged at #9)

This ordering prioritizes the most actively maintained Android projects and collaboration tools at the top of the showcase.