### PR TITLE
Update Android Device Catalog card with both web and Android app links

### DIFF
--- a/index.html
+++ b/index.html
@@ -621,14 +621,17 @@
                                         </div>
                                         <div class="artifact-info">
                                             <h4 class="artifact-title">Android Device Catalog</h4>
-                                            <p class="artifact-description">Interactive browser for exploring and analyzing Android devices from the official Device Catalog</p>
+                                            <p class="artifact-description">Interactive browser for exploring and analyzing Android devices from the official Device Catalog. Available as web app and native Android app.</p>
                                             <div class="artifact-tech">
                                                 <span class="tech-tag">React</span>
-                                                <span class="tech-tag">TypeScript</span>
                                                 <span class="tech-tag">Vite</span>
+                                                <span class="tech-tag">Android</span>
                                             </div>
                                             <a href="https://android-device.gohk.xyz/" target="_blank" class="artifact-link">
-                                                <i class="fas fa-external-link-alt"></i> See Android Catalog
+                                                <i class="fas fa-external-link-alt"></i> Web Browser
+                                            </a>
+                                            <a href="https://play.google.com/store/apps/details?id=dev.hossain.devicecatalog&pcampaignid=web_share" target="_blank" class="artifact-link">
+                                                <i class="fa-brands fa-google-play"></i> Get Android App
                                             </a>
                                         </div>
                                     </div>


### PR DESCRIPTION
## Summary
Updates the Android Device Catalog artifact card to showcase both the web application and the new native Android app.

## Changes
- ✨ Added Google Play Store link for the native Android app
- 📝 Updated description to mention both web and native versions
- 🏷️ Updated tech tags to: React, Vite, Android, Compose
- 🔗 Added two separate links: "Web Browser" and "Get Android App"

## Links
- Web App: https://android-device.gohk.xyz/
- Play Store: https://play.google.com/store/apps/details?id=dev.hossain.devicecatalog&pcampaignid=web_share