### PR TITLE
Update technology tags in artifact-info section

### DIFF
--- a/index.html
+++ b/index.html
@@ -865,8 +865,7 @@
                                             <h4 class="artifact-title">TRMNL Badges</h4>
                                             <p class="artifact-description">Dynamic SVG badges displaying statistics for TRMNL recipes with fast edge-based generation and official brand styling</p>
                                             <div class="artifact-tech">
-                                                <span class="tech-tag">Cloudflare Workers</span>
-                                                <span class="tech-tag">SVG</span>
+                                                <span class="tech-tag">Badge</span>
                                                 <span class="tech-tag">TypeScript</span>
                                             </div>
                                             <a href="https://github.com/hossain-khan/trmnl-badges" target="_blank" class="artifact-link">


### PR DESCRIPTION
Replaced 'Cloudflare Workers' and 'SVG' tags with 'Badge' tag.