### PR TITLE
Update Medium.com links to hossain.dev

### DIFF
--- a/archive/_template.html
+++ b/archive/_template.html
@@ -67,8 +67,8 @@
                             <li class="list-inline-item"><a href="https://androiddev.social/@hossainkhan"
                                     target="_blank" aria-label="Mastodon Profile"><i class="fab fa-mastodon"></i></a>
                             </li>
-                            <li class="list-inline-item"><a href="https://medium.com/@hossainkhan" target="_blank"
-                                    aria-label="Blog on Medium.com"><i class="fab fa-medium"></i></a></li>
+                            <li class="list-inline-item"><a href="https://hossain.dev/" target="_blank"
+                                    aria-label="Blog"><i class="fa-solid fa-blog"></i></a></li>
                             <li class="list-inline-item"><a href="https://www.linkedin.com/in/hossain" target="_blank"
                                     aria-label="LinkedIn Profile"><i class="fab fa-linkedin-in"></i></a></li>
                             <li class="list-inline-item"><a href="https://github.com/hossain-khan" target="_blank"

--- a/archive/dubdub/video-preview.html
+++ b/archive/dubdub/video-preview.html
@@ -50,7 +50,7 @@
                 <ul class="social list-inline">
                     <li><a href="https://x.com/hossainkhan" target="_blank" aria-label="Twitter [X] Profile"><i class="fab fa-twitter"></i></a></li>
                     <li><a href="https://androiddev.social/@hossainkhan" target="_blank" aria-label="Mastodon Profile"><i class="fab fa-mastodon"></i></a></li>
-                    <li><a href="https://medium.com/@hossainkhan" target="_blank" aria-label="Blog on Medium.com"><i class="fab fa-medium"></i></a></li>
+                    <li><a href="https://hossain.dev/" target="_blank" aria-label="Blog"><i class="fa-solid fa-blog"></i></a></li>
                     <li><a href="https://www.linkedin.com/in/hossain" target="_blank" aria-label="LinkedIn Profile"><i class="fab fa-linkedin-in"></i></a></li>
                     <li><a href="https://github.com/hossain-khan" target="_blank" aria-label="Github Profile"><i class="fab fa-github-alt"></i></a></li>
                     <li><a href="https://stackoverflow.com/users/132121/hossain-khan" target="_blank" aria-label="StackOverflow Profile"><i class="fab fa-stack-overflow"></i></a></li>

--- a/archive/google.dev-badges/browse.html
+++ b/archive/google.dev-badges/browse.html
@@ -65,8 +65,8 @@
                             <li class="list-inline-item"><a href="https://androiddev.social/@hossainkhan"
                                     target="_blank" aria-label="Mastodon Profile"><i class="fab fa-mastodon"></i></a>
                             </li>
-                            <li class="list-inline-item"><a href="https://medium.com/@hossainkhan" target="_blank"
-                                    aria-label="Blog on Medium.com"><i class="fab fa-medium"></i></a></li>
+                            <li class="list-inline-item"><a href="https://hossain.dev/" target="_blank"
+                                    aria-label="Blog"><i class="fa-solid fa-blog"></i></a></li>
                             <li class="list-inline-item"><a href="https://www.linkedin.com/in/hossain" target="_blank"
                                     aria-label="LinkedIn Profile"><i class="fab fa-linkedin-in"></i></a></li>
                             <li class="list-inline-item"><a href="https://github.com/hossain-khan" target="_blank"

--- a/archive/travel/where-to.html
+++ b/archive/travel/where-to.html
@@ -61,8 +61,8 @@
                             <li class="list-inline-item"><a href="https://androiddev.social/@hossainkhan"
                                     target="_blank" aria-label="Mastodon Profile"><i class="fab fa-mastodon"></i></a>
                             </li>
-                            <li class="list-inline-item"><a href="https://medium.com/@hossainkhan" target="_blank"
-                                    aria-label="Blog on Medium.com"><i class="fab fa-medium"></i></a></li>
+                            <li class="list-inline-item"><a href="https://hossain.dev/" target="_blank"
+                                    aria-label="Blog"><i class="fa-solid fa-blog"></i></a></li>
                             <li class="list-inline-item"><a href="https://www.linkedin.com/in/hossain" target="_blank"
                                     aria-label="LinkedIn Profile"><i class="fab fa-linkedin-in"></i></a></li>
                             <li class="list-inline-item"><a href="https://github.com/hossain-khan" target="_blank"

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -139,7 +139,7 @@ window.addEventListener('DOMContentLoaded', function() {
 	const rss = new RSS(
 	    document.querySelector("#rss-feeds"),
 	    //Change this to your own rss feeds
-        "https://medium.com/feed/@hossainkhan",
+        "https://hossain.dev/rss.xml",
 	    {
 		     // how many entries do you want?
 		    // default: 4

--- a/index.html
+++ b/index.html
@@ -80,7 +80,7 @@
             "https://github.com/hossain-khan",
             "https://linkedin.com/in/hossainkhan",
             "https://twitter.com/amardeshbd",
-            "https://hossainkhan.medium.com"
+            "https://hossain.dev/"
         ],
         "worksFor": {
             "@type": "Organization",
@@ -129,7 +129,7 @@
                             <li class="list-inline-item"><a href="https://bsky.app/profile/hossain.dev" target="_blank" aria-label="Bluesky 🦋 Profile"><i class="fa-brands fa-bluesky"></i></a></li>
                             <!-- <li class="list-inline-item"><a href="https://x.com/hossainkhan" target="_blank" aria-label="Twitter [X] Profile"><i class="fab fa-twitter"></i></a></li> -->
                             <li class="list-inline-item"><a href="https://androiddev.social/@hossainkhan" target="_blank" aria-label="Mastodon Profile"><i class="fab fa-mastodon"></i></a></li>
-                            <li class="list-inline-item"><a href="https://medium.com/@hossainkhan" target="_blank" aria-label="Blog on Medium.com"><i class="fab fa-medium"></i></a></li>
+                            <li class="list-inline-item"><a href="https://hossain.dev/" target="_blank" aria-label="Blog"><i class="fa-solid fa-blog"></i></a></li>
                             <li class="list-inline-item"><a href="https://www.linkedin.com/in/hossain" target="_blank" aria-label="LinkedIn Profile"><i class="fab fa-linkedin-in"></i></a></li>
                             <li class="list-inline-item"><a href="https://github.com/hossain-khan" target="_blank" aria-label="Github Profile"><i class="fab fa-github-alt"></i></a></li>
                             <!-- <li class="list-inline-item"><a href="https://stackoverflow.com/users/132121/hossain-khan" target="_blank" aria-label="StackOverflow Profile"><i class="fab fa-stack-overflow"></i></a></li> -->
@@ -394,7 +394,7 @@
                                     <p>The application is Open Source and available in <i class="fab fa-github-alt"></i> <a href="https://github.com/hossain-khan/android-hk-vision-muzei-plugin" target="_blank">Github</a>. If you have a similar source, you may also be interested in creating a plugin for it <i class="far fa-thumbs-up" aria-hidden="true"></i></p>
                                     <p>
                                         <a class="more-link" href="https://play.google.com/store/apps/details?id=com.hossainkhan.vision" target="_blank"><i class="fas fa-external-link-alt"></i> Get it on Google Play&trade;</a> &nbsp;&nbsp;
-                                        <a class="more-link" href="https://medium.com/@hossainkhan/hackathon-creating-the-simplest-muzei-wallpaper-plugin-for-android-9d080dbb4bf" target="_blank"><i class="fas fa-external-link-alt"></i> Read more on Medium</a>
+                                        <a class="more-link" href="https://hossain.dev/posts/hackathon-creating-the-simplest-muzei-wallpaper-plugin-for-android/" target="_blank"><i class="fas fa-external-link-alt"></i> Read article</a>
                                     </p>
                                 </div><!--//desc-->
                             </div><!--//item-->
@@ -1250,7 +1250,7 @@
                                 <li><i class="fas fa-envelope"></i><span class="sr-only">Email:</span><a href="mailto:hello@hossain.dev?Subject=Hello%20there">hello@hossain.dev</a></li>
                                 <li><i class="fas fa-link"></i><span class="sr-only">Website:</span><a href="#">hossainkhan.com</a></li>
                                 <li><i class="fas fa-camera"></i><span class="sr-only">Portfolio:</span><a href="https://vision.hossainkhan.com/">vision.hossainkhan.com</a></li>
-                                <li><i class="fas fa-pencil-alt"></i><span class="sr-only">Blog:</span><a href="https://hossainkhan.medium.com/">hossainkhan.medium.com</a></li>
+                                <li><i class="fas fa-pencil-alt"></i><span class="sr-only">Blog:</span><a href="https://hossain.dev/">hossain.dev</a></li>
                             </ul>
                         </div><!--//content-->
                     </div><!--//section-inner-->

--- a/testimonials.html
+++ b/testimonials.html
@@ -85,7 +85,7 @@
                 "https://github.com/hossain-khan",
                 "https://linkedin.com/in/hossainkhan",
                 "https://twitter.com/amardeshbd",
-                "https://hossainkhan.medium.com"
+                "https://hossain.dev/"
             ]
         },
         "breadcrumb": {
@@ -139,8 +139,8 @@
                             <li class="list-inline-item"><a href="https://androiddev.social/@hossainkhan"
                                     target="_blank" aria-label="Mastodon Profile"><i class="fab fa-mastodon"></i></a>
                             </li>
-                            <li class="list-inline-item"><a href="https://medium.com/@hossainkhan" target="_blank"
-                                    aria-label="Blog on Medium.com"><i class="fab fa-medium"></i></a></li>
+                            <li class="list-inline-item"><a href="https://hossain.dev/" target="_blank"
+                                    aria-label="Blog"><i class="fa-solid fa-blog"></i></a></li>
                             <li class="list-inline-item"><a href="https://www.linkedin.com/in/hossain" target="_blank"
                                     aria-label="LinkedIn Profile"><i class="fab fa-linkedin-in"></i></a></li>
                             <li class="list-inline-item"><a href="https://github.com/hossain-khan" target="_blank"


### PR DESCRIPTION
## Overview
Migrate all Medium.com references to hossain.dev as the primary blog platform.

## Changes
- **Header social links**: Update from `medium.com/@hossainkhan` to `hossain.dev` with new blog icon (`fa-solid fa-blog`)
- **Blog article link**: Direct reference to new hossain.dev post URL
- **Contact card**: Update blog link to `hossain.dev`
- **JSON-LD schema**: Update `sameAs` URLs to point to `hossain.dev`
- **RSS feed**: Change from Medium.com feed to `https://hossain.dev/rss.xml`

## Files Changed
### Main Pages
- `index.html` - Header social links, article link, contact card, JSON-LD schema
- `testimonials.html` - Header social links, JSON-LD schema
- `assets/js/main.js` - RSS feed configuration

### Archive Files (Historical snapshots)
- `archive/_template.html`
- `archive/dubdub/video-preview.html`
- `archive/google.dev-badges/browse.html`
- `archive/travel/where-to.html`