### PR TITLE
Add Android Compose Highlight to Vibe Artifacts

### DIFF
--- a/index.html
+++ b/index.html
@@ -899,6 +899,28 @@
                                         </div>
                                     </div>
 
+                                    <!-- Project Card 17: Android Compose Highlight -->
+                                    <div class="artifact-card">
+                                        <div class="artifact-thumbnail">
+                                            <i class="fas fa-code"></i>
+                                        </div>
+                                        <div class="artifact-info">
+                                            <h4 class="artifact-title">Android Compose Highlight</h4>
+                                            <p class="artifact-description">Jetpack Compose library for beautiful syntax highlighting powered by Highlight.js. Supports 190+ languages with native text selection and accessibility via hidden WebView bridge.</p>
+                                            <div class="artifact-tech">
+                                                <span class="tech-tag">Android</span>
+                                                <span class="tech-tag">Compose</span>
+                                                <span class="tech-tag">Highlight.js</span>
+                                            </div>
+                                            <a href="https://github.com/hossain-khan/android-compose-highlight" target="_blank" class="artifact-link">
+                                                <i class="fas fa-external-link-alt"></i> View on GitHub
+                                            </a>
+                                            <a href="https://hossain.dev/posts/syntax-highlighting-on-android-highlight-js-native-compose-engine/" target="_blank" class="artifact-link">
+                                                <i class="fas fa-newspaper"></i> Blog Post
+                                            </a>
+                                        </div>
+                                    </div>
+
                                     <!-- Placeholder for future projects (always keep as last item) -->
                                     <div class="artifact-card placeholder">
                                         <div class="artifact-thumbnail">

--- a/index.html
+++ b/index.html
@@ -192,7 +192,7 @@
                                 devices. Recently, I've been investing heavily in learning AI tools and development workflows,
                                 exploring platforms like Claude Code, Gemini CLI, Cursor, GitHub Copilot, and GitHub Spark.
                                 This AI-assisted approach has revolutionized my development process, enabling rapid prototyping
-                                and innovative solutions showcased in my <a href="#vibe-artifacts" class="text-decoration-none" style="color: #5b86b7;">Vibe Coded Artifacts</a>.</p>
+                                and innovative solutions showcased in my <a href="#vibe-artifacts" class="text-decoration-none" style="color: inherit; opacity: 0.7;">Vibe Coded Artifacts</a>.</p>
 
                             <p>Beyond code, continuous learning and creativity come from tech news, TED Talks, and
                                 YouTube. I'm particularly fascinated by the intersection of traditional software development and emerging AI capabilities. Feel free to reach out for mentorship or collaboration on AI-assisted development projects. Let’s


### PR DESCRIPTION
## Changes

- Added Android Compose Highlight as artifact #17
- Jetpack Compose library for syntax highlighting powered by Highlight.js
- Supports 190+ languages with native text selection and accessibility
- Tech stack: Android, Compose, Highlight.js

## Links
- GitHub: https://github.com/hossain-khan/android-compose-highlight
- Blog: https://hossain.dev/posts/syntax-highlighting-on-android-highlight-js-native-compose-engine/